### PR TITLE
Display activation message into status bar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,7 +34,7 @@ export function activate(context: vscode.ExtensionContext) {
 		setTimeout(() => {
 			vscode.commands.executeCommand(command)
 							.then(
-								() => vscode.window.showInformationMessage(`[Auto Run Command] Condition met - ${message}`),
+								() => vscode.window.setStatusBarMessage(`[Auto Run Command] Condition met - ${message}`, 3000),
 								(reason) => vscode.window.showErrorMessage(`[Auto Run Command] Condition met but command [${command}] raised an error - [${reason}] `)
 							);
 		}, safetyDelay);


### PR DESCRIPTION
Hi 👋  thx for great extension, I enjoy it.

This PR changes behavior of activation notification, instead of show it as `informationMessage`, display it into status bar and auto-dismiss it after certain period (3sec, in this PR). Primary reason for this is those activation message is appearing each time starting editor and have to dismiss manually, but in case of successful activation with correct setup probably user won't need to be notified over requires manual dismiss. With this PR message will looks like below in status bar.

![image](https://cloud.githubusercontent.com/assets/1210596/21403467/b6fe48a4-c771-11e6-933a-202a2f91fb28.png)
