### PR TITLE
Change meaning of commands parameter when array.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,23 @@
                             "message": {
                                 "type": "string",
                                 "description": "A descriptive message to show when the condition is met. Defaults to the robotic condition text"
+                            },
+                            "cmd": {
+                                "type": ["object", null],
+                                "properties": {
+                                    "command": {
+                                        "type": [
+                                            "string",
+                                            "array"
+                                        ],
+                                        "description": "Command to run when the rule is matched"
+                                        },
+                                    "args": {
+                                        "type": [
+                                            "array"
+                                        ]
+                                    }
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
There is not currently a way to pass arguments to the commands executed by the extension.  This has the annoying effect of meaning that vs-code-auto-run can't invoke any user defined tasks using the Tasks api in vscode.

This pr changes the meaning of command when command is a string[].  Given config:

```
  "auto-run-command.rules": [
    {
      "condition": "isRootFolder: my_cool_project",
      "command": ["workbench.action.tasks.runTask", "my_cool_task"],
      "message": "Running my_cool_task"
    }
```

**Previous behavior**: run executeCommand("workbench.action.tasks.runTask) and then run executeCommand("my_cool_task")

**New behavior**: run executeCommand("workbench.action.tasks.runTask", ...["my_cool_task"])