### PR TITLE
Add ability to pass arguments to commands

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,8 +32,10 @@ export function activate(context: vscode.ExtensionContext) {
 		const safetyDelay = 5000; //to ensure other extensions got their moves on
 		const commands = command.split(" "); // commands may contain specified to separate arguments
 
+		const [cmd, ...args] = commands;
+
 		setTimeout(() => {
-			vscode.commands.executeCommand(...commands)
+			vscode.commands.executeCommand(cmd, ...args)
 							.then(
 								() => vscode.window.setStatusBarMessage(`[Auto Run Command] Condition met - ${message}`, 3000),
 								(reason) => vscode.window.showErrorMessage(`[Auto Run Command] Condition met but command [${command}] raised an error - [${reason}] `)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,9 @@ export function activate(context: vscode.ExtensionContext) {
 		const safetyDelay = 5000; //to ensure other extensions got their moves on
 		const commands = command.split(" "); // commands may contain specified to separate arguments
 
+		if(commands.length < 1) {
+			return;
+		}
 		const [cmd, ...args] = commands;
 
 		setTimeout(() => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -30,9 +30,10 @@ export function activate(context: vscode.ExtensionContext) {
 	const runCommandDelayed = (command: string, message: string) => {
 
 		const safetyDelay = 5000; //to ensure other extensions got their moves on
+		const commands = command.split(" "); // commands may contain specified to separate arguments
 
 		setTimeout(() => {
-			vscode.commands.executeCommand(command)
+			vscode.commands.executeCommand(...commands)
 							.then(
 								() => vscode.window.setStatusBarMessage(`[Auto Run Command] Condition met - ${message}`, 3000),
 								(reason) => vscode.window.showErrorMessage(`[Auto Run Command] Condition met but command [${command}] raised an error - [${reason}] `)


### PR DESCRIPTION
Split command string into an array with space separator and pass to executeCommand as an array so that commands with arguments are correctly interpreted.

Should be backwards compatible and shouldn't change behavior of any existing use cases.