### PR TITLE
fix(checkcondition): prevent exception when file is not exists

### DIFF
--- a/src/lib/condition-checker.ts
+++ b/src/lib/condition-checker.ts
@@ -1,4 +1,4 @@
-import { ParsedCondition, ParsedConditionType} from './condition-parser';
+import { ParsedCondition, ParsedConditionType } from './condition-parser';
 import * as vscode from 'vscode';
 
 export const checkCondition = async (rule: ParsedCondition): Promise<boolean> => {
@@ -12,7 +12,7 @@ export const checkCondition = async (rule: ParsedCondition): Promise<boolean> =>
 			return editor && editor.document.languageId === args[0];
 		case ParsedConditionType.hasFile:
 			const results = await vscode.workspace.findFiles(args[0], '', 1);
-			return results.length > 0;
+			return Array.isArray(results) && results.length > 0;
 		case ParsedConditionType.isRootFolder:
 			const rootPath = vscode.workspace.rootPath || '';
 			const folderMatches = rootPath.match(/([^\/]*)\/*$/);


### PR DESCRIPTION
There is unhandled exception like below:

```

/C:/Program Files/Microsoft VS Code/resources/app/out/vs/workbench/workbench.main.js:4056 TypeError: Cannot read property 'length' of undefined
	at Object.<anonymous> (C:\Users\kwono\.vscode\extensions\gabrielgrinberg.auto-run-command-1.1.0\out\src\lib\condition-checker.js:22:27)
	at Generator.next (<anonymous>)
	at fulfilled (C:\Users\kwono\.vscode\extensions\gabrielgrinberg.auto-run-command-1.1.0\out\src\lib\condition-checker.js:4:58)
	at <anonymous>
e.$onExtensionRuntimeError @ /C:/Program Files/Microsoft VS Code/resources/app/out/vs/workbench/workbench.main.js:4056
```

when `findFiles` returns undefined by not able to find specific files. This PR adds small guards to prevent it.